### PR TITLE
install curl to upload compile info

### DIFF
--- a/CAPI/Dockerfile_compile
+++ b/CAPI/Dockerfile_compile
@@ -1,7 +1,8 @@
 FROM ubuntu
 Maintainer eesast.com
 WORKDIR /usr/local
-RUN apt-get update && apt-get install --no-install-recommends -y gcc g++ make libprotobuf-dev wget
+RUN mkdir /usr/local/mnt
+RUN apt-get update && apt-get install --no-install-recommends -y gcc g++ make libprotobuf-dev wget curl
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.15.7/cmake-3.15.7-Linux-x86_64.tar.gz --no-check-certificate \
 	&& tar -zxvf cmake-3.15.7-Linux-x86_64.tar.gz && rm cmake-3.15.7-Linux-x86_64.tar.gz
 ENV PATH=$PATH:/usr/local/cmake-3.15.7-Linux-x86_64/bin

--- a/CAPI/compile.sh
+++ b/CAPI/compile.sh
@@ -10,12 +10,12 @@ mkdir build
 cd build
 cmake ..
 make >error.txt 2>&1
-cp AI /usr/local/mnt/AI
+cp AI /usr/local/mnt/AI${THUAI_CODEROLE}
 if [ $? -ne 0]
 then
 	# compile fail
 	cp error.txt /usr/local/mnt/error.txt
-	curl -X PUT -d '{"compileInfo":@error.txt}' -H 'Content-Type: application/json' -H "Authorization: Bearer ${THUAI_COMPILE_TOKEN}" https://api.eesast.com/${THUAI_CODEID}/compile
+	curl -X PUT -d '{"compileInfo":@error.txt}' -H 'Content-Type: application/json' -H "Authorization: Bearer ${THUAI_COMPILE_TOKEN}" https://api.eesast.com/v1/codes/${THUAI_CODEID}/compile
 else
-	curl -X PUT -d '{"compileInfo":"compile success"}' -H 'Content-Type: application/json' -H "Authorization: Bearer ${THUAI_COMPILE_TOKEN}" https://api.eesast.com/${THUAI_CODEID}/compile
+	curl -X PUT -d '{"compileInfo":"compile success"}' -H 'Content-Type: application/json' -H "Authorization: Bearer ${THUAI_COMPILE_TOKEN}" https://api.eesast.com/v1/codes/${THUAI_CODEID}/compile
 fi

--- a/CAPI/compile.sh
+++ b/CAPI/compile.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 cd /usr/local/CAPI
+cp /usr/local/mnt/player.cpp ./src/player.cpp
 cat src/player.cpp | grep "#define DEVELOPER_ONLY"
 if [ $? -ne 1 ];then
 	echo "file inclusion error" >> error.txt
@@ -9,3 +10,12 @@ mkdir build
 cd build
 cmake ..
 make >error.txt 2>&1
+cp AI /usr/local/mnt/AI
+if [ $? -ne 0]
+then
+	# compile fail
+	cp error.txt /usr/local/mnt/error.txt
+	curl -X PUT -d '{"compileInfo":@error.txt}' -H 'Content-Type: application/json' -H "Authorization: Bearer ${THUAI_COMPILE_TOKEN}" https://api.eesast.com/${THUAI_CODEID}/compile
+else
+	curl -X PUT -d '{"compileInfo":"compile success"}' -H 'Content-Type: application/json' -H "Authorization: Bearer ${THUAI_COMPILE_TOKEN}" https://api.eesast.com/${THUAI_CODEID}/compile
+fi


### PR DESCRIPTION
- 安装curl，用于上传编译信息
- 加入/usr/local/mnt用于和服务器上路径绑定，用于拷贝player.cpp进行编译和存放编译后的AI或error.txt

注意：sh脚本中写死了api.eesast.com，根据curl用法或许可以执行，不过等待api加入相应功能测试后再merge比较好